### PR TITLE
Control behavior when keys are missing.

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,8 @@
+FROM golang:alpine
+RUN apk add git
+RUN apk add bash
+WORKDIR /go/src/github.com/subfuzion/envtpl
+COPY . .
+RUN go get -d -v ./...
+RUN go install -v ./...
+CMD ./test/test.sh

--- a/README.md
+++ b/README.md
@@ -23,10 +23,17 @@ match the keys of the internal environment variable map object (see example).
 
 ## Usage
 
-    envtpl [-o|--output outfile] [template]
+    envtpl [-o|--output outfile] [-m|--missing option] [template]
 
 * If `template` is not provided, `envtpl` reads from `stdin`
-* If `outfile` is not provide, `envtpl` writes to `stdout`
+* If `outfile` is not provided, `envtpl` writes to `stdout`
+* If `missing` is unset, `envtpl` follows the default behavior of
+  [the golang template library](https://golang.org/pkg/text/template/#Template.Option)
+  and missing keys in the template will be filled in with the string
+  `<no value>`.  If `missing` is set to `zero`, missing keys will be
+  filled in with the zero value for their data type (ie: an empty
+  string).  If `missing` is set to `error`, `envtpl` will fail and
+  an error returned to the caller.
 
 ## Example
 
@@ -45,6 +52,12 @@ Render the template (assume the value of `$USER` is 'mary')
     envtpl < greeting.tpl > out.txt  # writes "Hello mary" to out.txt
 
     cat greeting.tpl | envtpl > out.txt  # writes "Hello mary" to out.txt
+
+    unset USER; envtpl greeting.tpl  # writes "Hello <no value>" to stdout
+
+    unset USER; envtpl -m zero greeting.tpl  # writes "Hello " to stdout
+
+    unset USER; envtpl -m error greeting.tpl  # logs an error `map has no entry for key "USER"` and aborts
 
 `test/test.tpl` tests conditional functions as well as loop on environment variables. the `test/test/sh` script compares the output of envtpl with the expected output and can be used as unit test.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 var err error
 var output string
+var missing string
 
 func checkError(err error) {
 	if err != nil {
@@ -54,6 +55,11 @@ var RootCmd = &cobra.Command{
 			w = os.Stdout
 		}
 
+		// set error handling strategy for missing keys
+		if missing != "default" {
+			t = t.Option("missingkey=" + missing)
+		}
+
 		// render the template
 		err := t.Execute(w, env)
 		checkError(err)
@@ -67,6 +73,7 @@ func Execute() {
 
 func init() {
 	RootCmd.Flags().StringVarP(&output, "output", "o", "", "The rendered output file")
+	RootCmd.Flags().StringVarP(&missing, "missing", "m", "default", "Strategy for dealing with missing keys: default, zero or error")
 }
 
 func parse(s string) (*template.Template, error) {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+COMMIT_SHA=$(git rev-parse --short HEAD)
+docker build -t envtpltest:$COMMIT_SHA -f ./Dockerfile.test .
+docker run envtpltest:$COMMIT_SHA

--- a/test/test-missing.txt
+++ b/test/test-missing.txt
@@ -1,0 +1,13 @@
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "2s"
+  round_interval = true
+  hostname = "<no value>"
+
+[[outputs.influxdb]]
+
+# kafka output is disabled
+
+Environment variables starting with TAG_:
+TAG_DATACENTER="dc1"
+TAG_REGION="eu-west-1"

--- a/test/test-zero.txt
+++ b/test/test-zero.txt
@@ -1,0 +1,13 @@
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "2s"
+  round_interval = true
+  hostname = ""
+
+[[outputs.influxdb]]
+
+# kafka output is disabled
+
+Environment variables starting with TAG_:
+TAG_DATACENTER="dc1"
+TAG_REGION="eu-west-1"

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,18 +3,59 @@
 TMPFILE=$(mktemp)
 TESTDIR=$(dirname $0)
 program=envtpl
-cmd=$(dirname $0)/../$program
+cmd=$GOPATH/bin/$program
 
+if ! [ -x "$cmd" ]; then
+  echo "*** Cannot find $cmd"
+  exit 1
+fi
+
+echo "*** test with all variables set"
 TAG_REGION=eu-west-1 TAG_DATACENTER=dc1 INTERVAL=2s OUTPUT_INFLUXDB_ENABLED=true HOSTNAME=localhost ${cmd} ${TESTDIR}/test.tpl > ${TMPFILE}
 diff "${TESTDIR}/test.txt" "${TMPFILE}" >/dev/null
 if [[ $? -ne 0 ]]; then
-	echo "$program does not produce expected result"
-	echo "expected result:"
+	echo "*** $program does not produce expected result"
+	echo "*** expected result:"
 	cat "${TESTDIR}/test.txt"
-	echo "observed result:"
+	echo "*** observed result:"
 	cat "${TMPFILE}"
 	rm "${TMPFILE}"
-	return 1
+	exit 1
 fi
-echo "Tests passed successfully"
+
+unset HOSTNAME
+echo "*** test with missing variable but default missing behavior"
+TAG_REGION=eu-west-1 TAG_DATACENTER=dc1 INTERVAL=2s OUTPUT_INFLUXDB_ENABLED=true ${cmd} ${TESTDIR}/test.tpl > ${TMPFILE}
+diff "${TESTDIR}/test-missing.txt" "${TMPFILE}" >/dev/null
+if [[ $? -ne 0 ]]; then
+	echo "*** $program does not produce expected result"
+	echo "*** expected result:"
+	cat "${TESTDIR}/test-missing.txt"
+	echo "*** observed result:"
+	cat "${TMPFILE}"
+	rm "${TMPFILE}"
+	exit 1
+fi
+
+echo "*** test with missing variable but zero missing behavior"
+TAG_REGION=eu-west-1 TAG_DATACENTER=dc1 INTERVAL=2s OUTPUT_INFLUXDB_ENABLED=true ${cmd} -m zero ${TESTDIR}/test.tpl > ${TMPFILE}
+diff "${TESTDIR}/test-zero.txt" "${TMPFILE}" >/dev/null
+if [[ $? -ne 0 ]]; then
+	echo "*** $program does not produce expected result"
+	echo "*** expected result:"
+	cat "${TESTDIR}/test-zero.txt"
+	echo "*** observed result:"
+	cat "${TMPFILE}"
+	rm "${TMPFILE}"
+	exit 1
+fi
+
+echo "*** test with missing variable and error behavior"
+TAG_REGION=eu-west-1 TAG_DATACENTER=dc1 INTERVAL=2s OUTPUT_INFLUXDB_ENABLED=true ${cmd} -m error ${TESTDIR}/test.tpl > ${TMPFILE}
+if [[ $? -eq 0 ]]; then
+	echo "*** $program returned no error when it should have!"
+	exit 1
+fi
+
+echo "*** Tests passed successfully"
 rm "${TMPFILE}"


### PR DESCRIPTION
This PR adds a `-m` / `--missing` flag, allowing the caller
to choose envtpl's behavior in the face of missing environment
keys when found in the template.  The options are taken from
https://golang.org/pkg/text/template/#Template.Option

Tests are added to validate this behavior.

Additionally:

- add a Dockerfile.test and top-level test.sh script to ease
  the build/test cycle on non-linux platforms

- decorate the output of `test/test.sh` to more clearly distinguish
  between the output of the test script and of the commands it calls